### PR TITLE
Reference path fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "samplesheet"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 publish = false
 

--- a/src/tracking_sheet.rs
+++ b/src/tracking_sheet.rs
@@ -10,7 +10,11 @@ pub trait FromTrackingSheetDir: Sized + DeserializeOwned {
 
     fn from_tracking_sheet_dir(dir: &Utf8Path) -> anyhow::Result<Vec<Self>> {
         let path = dir.join(Self::filename());
-        let contents = fs::read_to_string(&path).context(format!("failed to read {path}"))?.split('\n').skip(Self::header_row()).join("\n");
+        let contents = fs::read_to_string(&path)
+            .context(format!("failed to read {path}"))?
+            .split('\n')
+            .skip(Self::header_row())
+            .join("\n");
 
         let mut reader = csv::Reader::from_reader(contents.as_bytes());
         let records: anyhow::Result<Vec<_>, _> = reader.deserialize().collect();


### PR DESCRIPTION
The species of a sample (or set of samples) alone does not define the reference path to be used. This pull request fixes that so that the species, the tool, and the command define the reference path to be used.